### PR TITLE
Make scheduling less fragile

### DIFF
--- a/contentstore/tests.py
+++ b/contentstore/tests.py
@@ -153,6 +153,20 @@ class TestContentStoreApi(AuthenticatedAPITestCase):
         self.assertEqual(response.data["results"][1]["short_name"],
                          "messageset_two")
 
+    def test_filter_messagesets(self):
+        # Setup
+        self.make_messageset()
+        self.make_messageset(short_name='messageset_two')
+        # Execute
+        response = self.client.get('/api/v1/messageset/',
+                                   {'short_name': 'messageset_two'},
+                                   content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["short_name"],
+                         "messageset_two")
+
     def test_create_message(self):
         """
         A POST request should create a message object for a messageset.

--- a/scheduler/client.py
+++ b/scheduler/client.py
@@ -43,7 +43,7 @@ class SchedulerApiClient(object):
         result = {
             'get': self.session.get,
             'post': self.session.post,
-            'put': self.session.post,
+            'patch': self.session.patch,
             'delete': self.session.delete,
         }.get(method, None)(url, params=params, data=json.dumps(data))
         result.raise_for_status()
@@ -62,7 +62,7 @@ class SchedulerApiClient(object):
         return self.call('schedule', 'post', data=schedule)
 
     def update_schedule(self, schedule_id, schedule):
-        return self.call('schedule', 'put', obj=schedule_id,
+        return self.call('schedule', 'patch', obj=schedule_id,
                          data=schedule)
 
     def delete_schedule(self, schedule_id):

--- a/seed_stage_based_messaging/settings.py
+++ b/seed_stage_based_messaging/settings.py
@@ -177,6 +177,9 @@ CELERY_ROUTES = {
     'subscriptions.tasks.schedule_create': {
         'queue': 'priority',
     },
+    'subscriptions.tasks.schedule_disable': {
+        'queue': 'priority',
+    },
     'subscriptions.tasks.fire_metric': {
         'queue': 'metrics',
     },

--- a/subscriptions/models.py
+++ b/subscriptions/models.py
@@ -49,6 +49,14 @@ def fire_sub_action_if_new(sender, instance, created, **kwargs):
         schedule_create.apply_async(args=[str(instance.id)])
 
 
+# Deactivate the schedule for this subscription when completed
+@receiver(post_save, sender=Subscription)
+def disable_schedule_if_complete(sender, instance, created, **kwargs):
+    from .tasks import schedule_disable
+    if instance.completed is True or instance.process_status == 2:
+        schedule_disable.apply_async(args=[str(instance.id)])
+
+
 @receiver(post_save, sender=Subscription)
 def fire_metrics_if_new(sender, instance, created, **kwargs):
     from .tasks import fire_metric

--- a/subscriptions/tasks.py
+++ b/subscriptions/tasks.py
@@ -378,23 +378,15 @@ class ScheduleCreate(Task):
         try:
             subscription = Subscription.objects.get(id=subscription_id)
             if subscription.process_status == 0:
-                scheduler = self.scheduler_client()
-                # get the messageset length for frequency calc
-                message_count = subscription.messageset.messages.filter(
-                    lang=subscription.lang).count()
-                # next_sequence_number is for setting non-one start position
-                # frequency is the number of messages that should be sent
-                frequency = (
-                    message_count - subscription.next_sequence_number) + 1
-                # Build the schedule POST create object
                 schedule = {
-                    "frequency": frequency,
+                    "frequency": None,
                     "cron_definition":
                         self.schedule_to_cron(subscription.schedule),
                     "endpoint": "%s/%s/send" % (
                         settings.STAGE_BASED_MESSAGING_URL, subscription_id),
                     "auth_token": settings.SCHEDULER_INBOUND_API_TOKEN
                 }
+                scheduler = self.scheduler_client()
                 result = scheduler.create_schedule(schedule)
                 l.info("Created schedule <%s> on scheduler for sub <%s>" % (
                     result["id"], subscription_id))

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -402,7 +402,7 @@ class TestCreateScheduleTask(AuthenticatedAPITestCase):
                 "http://seed-stage-based-messaging/api/v1",
                 "subscription",
                 str(existing.id)),
-            "frequency": 2,
+            "frequency": None,
             "messages": None,
             "triggered": 0,
             "created_at": "2015-04-05T21:59:28Z",

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -17,7 +17,8 @@ from rest_framework.authtoken.models import Token
 from requests_testadapter import TestAdapter, TestSession
 from go_http.metrics import MetricsApiClient
 
-from .models import Subscription, fire_sub_action_if_new, fire_metrics_if_new
+from .models import (Subscription, fire_sub_action_if_new,
+                     disable_schedule_if_complete, fire_metrics_if_new)
 from contentstore.models import Schedule, MessageSet, BinaryContent, Message
 from .tasks import schedule_create, fire_metric, scheduled_metrics
 from . import tasks
@@ -154,6 +155,7 @@ class AuthenticatedAPITestCase(APITestCase):
             "Subscription model has no post_save listeners. Make sure"
             " helpers cleaned up properly in earlier tests.")
         post_save.disconnect(fire_sub_action_if_new, sender=Subscription)
+        post_save.disconnect(disable_schedule_if_complete, sender=Subscription)
         post_save.disconnect(fire_metrics_if_new, sender=Subscription)
         assert not has_listeners(), (
             "Subscription model still has post_save listeners. Make sure"
@@ -166,6 +168,7 @@ class AuthenticatedAPITestCase(APITestCase):
             "Subscription model still has post_save listeners. Make sure"
             " helpers removed them properly in earlier tests.")
         post_save.connect(fire_sub_action_if_new, sender=Subscription)
+        post_save.connect(disable_schedule_if_complete, sender=Subscription)
         post_save.connect(fire_metrics_if_new, sender=Subscription)
 
     def setUp(self):

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -271,6 +271,26 @@ class TestSubscriptionsAPI(AuthenticatedAPITestCase):
         self.assertEqual(d.process_status, 0)
         self.assertEqual(d.metadata["source"], "RapidProVoice")
 
+    def test_filter_subscription_data(self):
+        # Setup
+        sub_active = self.make_subscription()
+        sub_inactive = self.make_subscription()
+        sub_inactive.active = False
+        sub_inactive.save()
+        # Precheck
+        self.assertEqual(sub_active.active, True)
+        self.assertEqual(sub_inactive.active, False)
+        # Execute
+        response = self.client.get(
+            '/api/v1/subscriptions/',
+            {"identity": "8646b7bc-b511-4965-a90b-e1145e398703",
+             "active": "True"},
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], str(sub_active.id))
+
     def test_update_subscription_data(self):
         # Setup
         existing = self.make_subscription()


### PR DESCRIPTION
Currently stage-based-messaging is calculating the number of times the scheduler should run when a subscription is created: `frequency = (message_count - subscription.next_sequence_number) + 1`.
We should rather set the frequency to `None`, and add a post-save hook to the subscription model that deactivates the schedule when the subscription changes to `completed==True`/`process_status==2`.

This will prevent scheduler fragility where if a message fails to send properly, the scheduler send numbers gets out of sync with the subscription next_sequence_number, which could lead to users never receiving the last message and therefore, for instance, never reaching the next message set's messages.

This issue links with https://github.com/praekelt/seed-scheduler/issues/9