### PR TITLE
Subscription per language metric

### DIFF
--- a/seed_stage_based_messaging/utils.py
+++ b/seed_stage_based_messaging/utils.py
@@ -2,6 +2,7 @@ import re
 import requests
 from django.conf import settings
 from contentstore.models import MessageSet
+from subscriptions.models import Subscription
 
 
 NORMALISE_METRIC_RE = re.compile(r'\W+')
@@ -54,5 +55,14 @@ def get_available_metrics():
             "subscriptions.message_set.{}.sum".format(messageset_name))
         available_metrics.append(
             "subscriptions.message_set.{}.total.last".format(messageset_name))
+
+    subscriptions = Subscription.objects.all()
+    for subscription in subscriptions:
+        lang_key = "subscriptions.language.{}.sum".format(subscription.lang)
+        if (lang_key not in available_metrics):
+            available_metrics.append(lang_key)
+            available_metrics.append(
+                "subscriptions.language.{}.total.last"
+                .format(subscription.lang))
 
     return available_metrics

--- a/seed_stage_based_messaging/utils.py
+++ b/seed_stage_based_messaging/utils.py
@@ -56,13 +56,13 @@ def get_available_metrics():
         available_metrics.append(
             "subscriptions.message_set.{}.total.last".format(messageset_name))
 
-    subscriptions = Subscription.objects.all()
-    for subscription in subscriptions:
-        lang_key = "subscriptions.language.{}.sum".format(subscription.lang)
-        if (lang_key not in available_metrics):
-            available_metrics.append(lang_key)
-            available_metrics.append(
-                "subscriptions.language.{}.total.last"
-                .format(subscription.lang))
+    languages = Subscription.objects.order_by('lang').distinct('lang')\
+        .values_list('lang', flat=True)
+    for lang in languages:
+        lang_normal = normalise_metric_name(lang)
+        available_metrics.append(
+            "subscriptions.language.{}.sum".format(lang_normal))
+        available_metrics.append(
+            "subscriptions.language.{}.total.last".format(lang_normal))
 
     return available_metrics

--- a/subscriptions/models.py
+++ b/subscriptions/models.py
@@ -111,8 +111,9 @@ def fire_metric_per_lang(sender, instance, created, **kwargs):
     Fires metrics according to the language of the subscription.
     """
     from .tasks import fire_metric
+    from seed_stage_based_messaging.utils import normalise_metric_name
     if created:
-        lang = instance.lang
+        lang = normalise_metric_name(instance.lang)
         fire_metric.apply_async(kwargs={
             "metric_name": "subscriptions.language.{}.sum".format(lang),
             "metric_value": 1.0,


### PR DESCRIPTION
This PR will create the subscriptions.language.{language}.sum and subscriptions.language.{language}.total.last.