### PR TITLE
Management command to fix subscription lifecycle

### DIFF
--- a/subscriptions/management/commands/fix_subscription_lifecycle.py
+++ b/subscriptions/management/commands/fix_subscription_lifecycle.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from subscriptions.models import Subscription
+
+
+class Command(BaseCommand):
+    help = ("Fast forward subscriptions lifecycle up to given date. This "
+            "is used when the messages sending failed to get the subscription "
+            "up to date. Leave end_date blank for current date")
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--end_date", dest="end_date", default=datetime.now(),
+            type=lambda today: datetime.strptime(today, '%Y%m%d'),
+            help=("Fast forward subscription to end_date",
+                  "By default it will use datetime.now() (format YYYYMMDD)")
+        )
+
+    def handle(self, *args, **options):
+        end_date = options['end_date']
+        end_date = end_date.replace(tzinfo=timezone.utc)
+
+        updated = 0
+
+        subscriptions = Subscription.objects.all()
+
+        for sub in subscriptions:
+            updates = Subscription.fast_forward_lifecycle(sub, end_date)
+            updated += len(updates) - 1
+
+        self.stdout.write("%s subscription%s updated."
+                          % (updated, '' if updated == 1 else 's'))

--- a/subscriptions/management/commands/fix_subscription_lifecycle.py
+++ b/subscriptions/management/commands/fix_subscription_lifecycle.py
@@ -14,8 +14,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "--end_date", dest="end_date", default=datetime.now(),
             type=lambda today: datetime.strptime(today, '%Y%m%d'),
-            help=("Fast forward subscription to end_date",
-                  "By default it will use datetime.now() (format YYYYMMDD)")
+            help='''Fast forward subscription to end_date
+                  By default it will use datetime.now() (format YYYYMMDD)'''
         )
 
     def handle(self, *args, **options):

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -2400,3 +2400,78 @@ class TestSubscription(AuthenticatedAPITestCase):
         sub2 = result[1]
         self.assertEqual(sub1.completed, True)
         self.assertEqual(sub2.completed, False)
+
+
+class TestFixSubscriptionLifecycle(AuthenticatedAPITestCase):
+
+    def setUp(self):
+        super(TestFixSubscriptionLifecycle, self).setUp()
+
+        self.messageset_second = self.make_messageset_second()
+        self.messageset.next_set = self.messageset_second
+        self.messageset.save()
+
+        self.message = self.make_message()
+
+    def make_message(self):
+        message_data = {
+            'messageset': self.messageset,
+            'sequence_number': 1,
+            'lang': 'eng_ZA',
+            'text_content': 'This is a test message bro.',
+        }
+        return Message.objects.create(**message_data)
+
+    def make_messageset_second(self):
+        messageset_data = {
+            'short_name': 'messageset_second',
+            'notes': None,
+            'next_set': None,
+            'default_schedule': self.schedule,
+            'content_type': 'audio'
+        }
+        return MessageSet.objects.create(**messageset_data)
+
+    def test_noop(self):
+        stdout, stderr = StringIO(), StringIO()
+
+        self.make_subscription()
+
+        call_command('fix_subscription_lifecycle',
+                     stdout=stdout, stderr=stderr)
+
+        self.assertEqual(stderr.getvalue(), '')
+        self.assertEqual(
+            stdout.getvalue().strip(),
+            '0 subscriptions updated.')
+
+    def test_subscriptions_lifecycle_fix(self):
+        stdout, stderr = StringIO(), StringIO()
+
+        self.make_subscription()
+        sub1 = self.make_subscription()
+        sub1.created_at = datetime(2016, 1, 1, 0, 0, tzinfo=pytz.UTC)
+        sub1.save()
+
+        call_command('fix_subscription_lifecycle',
+                     stdout=stdout, stderr=stderr)
+
+        self.assertEqual(stderr.getvalue(), '')
+        self.assertEqual(
+            stdout.getvalue().strip(),
+            '1 subscription updated.')
+
+    def test_subscription_lifecycle_fix_with_args(self):
+        stdout, stderr = StringIO(), StringIO()
+
+        self.make_subscription()
+        self.make_subscription()
+
+        call_command('fix_subscription_lifecycle',
+                     '--end_date', '20170101',
+                     stdout=stdout, stderr=stderr)
+
+        self.assertEqual(stderr.getvalue(), '')
+        self.assertEqual(
+            stdout.getvalue().strip(),
+            '2 subscriptions updated.')


### PR DESCRIPTION
Management command to fix subscription lifecycle

Arguments:
end_date - Fast forward subscription to end_date, By default it will use datetime.now()