### PR TITLE
Make post send process not async

### DIFF
--- a/subscriptions/tasks.py
+++ b/subscriptions/tasks.py
@@ -278,9 +278,9 @@ class SendNextMessage(Task):
         l.debug("saving subscription")
         subscription.save()
 
-        l.debug("firing post_send_process task")
-        post_send_process.apply_async(args=[subscription_id])
-        l.debug("fired post_send_process task")
+        l.debug("starting post_send_process task")
+        post_send_process(subscription_id)
+        l.debug("finished post_send_process task")
 
         l.debug("Firing SMS/OBD calls sent per message set metric")
         send_type = utils.normalise_metric_name(


### PR DESCRIPTION
If the post send task does not complete by the time the schedule gets triggered again, then we enter a race condition where we send the same message again.

The fix we're doing here is to run the post send process synchronously, so that we're guaranteed that the subscription will get updated before the next message gets processed. Looking at historical data in the logs, this task runs in a very short time, so it won't have a big increase in the total run time of the send message task.