### PR TITLE
Added active and not complete filter and order

### DIFF
--- a/subscriptions/management/commands/remove_duplicate_subscriptions.py
+++ b/subscriptions/management/commands/remove_duplicate_subscriptions.py
@@ -80,6 +80,8 @@ class Command(BaseCommand):
             subscriptions = Subscription.objects.filter(**{
                 field: getattr(unique, field) for field in fields}
             )
+            subscriptions = subscriptions.filter(active=True, completed=False)
+            subscriptions = subscriptions.order_by('created_at')
             if len(subscriptions) == 1:
                 continue
             dates = [subscriptions[0].created_at]


### PR DESCRIPTION
We only want to remove active subscriptions that are not completed.

I also added a order by to make sure we don't deactivate the subscription that we updated with the `update_initial_sequence` command.