### PR TITLE
[MOMZA-748] Document process_status of -2

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -177,6 +177,7 @@ Fields
 **process_status**
     A integer flag representing the process status of this subscription.
 
+    | -2 = error
     | -1 = error
     | 0 = ready
     | 1 = in process


### PR DESCRIPTION
There are many subscriptions with this process_status but I can't find where it's assigned or what it means. I assume it's an error because it's a negative number.