### PR TITLE
Change default BROKER_URL

### DIFF
--- a/seed_stage_based_messaging/settings.py
+++ b/seed_stage_based_messaging/settings.py
@@ -163,7 +163,9 @@ REST_FRAMEWORK = {
 CELERY_RESULT_BACKEND = 'djcelery.backends.database:DatabaseBackend'
 CELERYBEAT_SCHEDULER = 'djcelery.schedulers.DatabaseScheduler'
 
-BROKER_URL = os.environ.get('BROKER_URL', 'redis://localhost:6379/0')
+BROKER_URL = os.environ.get(
+    'BROKER_URL',
+    'amqp://localhost:5672//seed_stage_based_messaging')
 
 CELERY_DEFAULT_QUEUE = 'seed_stage_based_messaging'
 CELERY_QUEUES = (


### PR DESCRIPTION
Everywhere else (production, docker-compose) we use a message queue like RabbitMQ as the Celery backed rather than Redis. It's possible to use Redis with Celery but I can't see anywhere that we do that.

Update the default to make it clear that it's normally a message queue.