### PR TITLE
Update Scheduler api client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ addons:
 services:
   - postgresql
 install:
-  - "pip install -e . --use-mirrors"
-  - "pip install -r requirements-dev.txt --use-wheel"
+  - "pip install -e ."
+  - "pip install -r requirements-dev.txt"
 script:
   - flake8
   - py.test

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'pytz==2015.7',
         'requests==2.9.1',
         'drfdocs==0.0.11',
-        'seed-services-client>=0.29.0',
+        'seed-services-client>=0.30.0',
         'croniter==0.3.13',
         'django-cache-url==1.3.1',
         'django-redis==4.7.0',

--- a/subscriptions/tasks.py
+++ b/subscriptions/tasks.py
@@ -408,8 +408,8 @@ class ScheduleDisable(Task):
 
     def scheduler_client(self):
         return SchedulerApiClient(
-            api_token=settings.SCHEDULER_API_TOKEN,
-            api_url=settings.SCHEDULER_URL)
+            settings.SCHEDULER_API_TOKEN,
+            settings.SCHEDULER_URL)
 
     def run(self, subscription_id, **kwargs):
         l = self.get_logger(**kwargs)
@@ -450,8 +450,8 @@ class ScheduleCreate(Task):
 
     def scheduler_client(self):
         return SchedulerApiClient(
-            api_token=settings.SCHEDULER_API_TOKEN,
-            api_url=settings.SCHEDULER_URL)
+            settings.SCHEDULER_API_TOKEN,
+            settings.SCHEDULER_URL)
 
     def run(self, subscription_id, **kwargs):
         """ Returns remote scheduler_id UUID


### PR DESCRIPTION
https://github.com/praekeltfoundation/seed-services-client/pull/40 Changed the argument names for the SchedulerApiClient. Passing them through as positional arguments means that the call will work for older and newer versions of the client.