### PR TITLE
Validate against special characters in Message

### DIFF
--- a/contentstore/models.py
+++ b/contentstore/models.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from datetime import datetime
 import os.path
 from rest_framework.serializers import ValidationError
@@ -5,6 +7,25 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
 from croniter import croniter
+
+
+def validate_special_characters(value):
+    unnecessary_special_characters = [
+        u'“',
+        u'”',
+        u'’',
+        u'–',
+    ]
+    errors = []
+
+    for character in value:
+        if character in unnecessary_special_characters:
+            errors.append(character)
+
+    if errors:
+        raise ValidationError(
+            u'Text "{0}" has special characters which can be replaced: {1}'
+            .format(value, ' '.join(errors)))
 
 
 @python_2_unicode_compatible
@@ -148,7 +169,8 @@ class Message(models.Model):
                                    null=False)
     sequence_number = models.IntegerField(null=False, blank=False)
     lang = models.CharField(max_length=6, null=False, blank=False)
-    text_content = models.TextField(null=True, blank=True)
+    text_content = models.TextField(
+        null=True, blank=True, validators=[validate_special_characters])
     binary_content = models.ForeignKey(BinaryContent,
                                        related_name='message',
                                        null=True, blank=True)

--- a/contentstore/tests/test_general.py
+++ b/contentstore/tests/test_general.py
@@ -11,7 +11,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.authtoken.models import Token
 
-from .models import Schedule, MessageSet, Message
+from ..models import Schedule, MessageSet, Message
 
 
 class APITestCase(TestCase):

--- a/contentstore/tests/test_models.py
+++ b/contentstore/tests/test_models.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from django.test import TestCase
+from rest_framework.serializers import ValidationError
+
+from ..models import Message, validate_special_characters
+from .test_general import MessageSetTestMixin
+
+
+class TestValidators(TestCase):
+    def test_special_characters_allows_normal_text(self):
+        self.assertEqual(validate_special_characters('ascii text!'), None)
+
+    def test_special_characters_rejects_bad_chars(self):
+        with self.assertRaises(ValidationError):
+            validate_special_characters(u'I said “hello"')
+
+        with self.assertRaises(ValidationError):
+            validate_special_characters(u'I said "hello”')
+
+        with self.assertRaises(ValidationError):
+            validate_special_characters(u'It’s over there')
+
+        with self.assertRaises(ValidationError):
+            validate_special_characters(u'Hello –')
+
+
+class TestMessage(MessageSetTestMixin, TestCase):
+    def test_raises_validation_error_for_special_chars(self):
+        messageset = self.make_messageset()
+        special_chars = u'This text has a special character – there'
+
+        with self.assertRaises(ValidationError):
+            m = Message.objects.create(
+                sequence_number=1,
+                messageset_id=messageset.id,
+                text_content=special_chars,)
+            m.full_clean()


### PR DESCRIPTION
If a message contains special characters it may be badly encoded when sent over SMS (depending on the carrier and device).

There are some characters which are frequently bad, easily replaceable with ascii characters and are hard to spot by eye.

This commit adds a validator to prevent them from being saved.

We said we'd do this in a separate ticket but it ended up being so straightforward I thought I'd go for it.