### PR TITLE
Remove subscription lookup from subscription send view

### DIFF
--- a/subscriptions/tasks.py
+++ b/subscriptions/tasks.py
@@ -381,13 +381,6 @@ class PostSendProcess(Task):
                 log.info("post_send_process not executed")
                 return "post_send_process not executed"
 
-        except ObjectDoesNotExist:
-            log.debug("subscription errored")
-            subscription.process_status = -1  # Errored
-            log.debug("saving subscription")
-            subscription.save()
-            logger.error('Unexpected error', exc_info=True)
-
         except SoftTimeLimitExceeded:
             logger.error(
                 'Soft time limit exceed processing message send search '

--- a/subscriptions/views.py
+++ b/subscriptions/views.py
@@ -53,17 +53,8 @@ class SubscriptionSend(APIView):
     def post(self, request, *args, **kwargs):
         """ Validates subscription data before creating Outbound message
         """
-        # Look up subscriber
-        subscription_id = kwargs["subscription_id"]
-        if Subscription.objects.filter(id=subscription_id).exists():
-            status = 201
-            accepted = {"accepted": True}
-            send_next_message.apply_async(args=[subscription_id])
-        else:
-            status = 400
-            accepted = {"accepted": False,
-                        "reason": "Missing subscription in control"}
-        return Response(accepted, status=status)
+        send_next_message.delay(kwargs['subscription_id'])
+        return Response({'accepted': True}, status=201)
 
 
 class SubscriptionRequest(APIView):


### PR DESCRIPTION
Currently, the subscription send view tries to see whether the subscription exists or not, then fires off a celery task, which also looks up the same subscription.

Since the scheduler does nothing with the returned error code except for retry the schedule, there is no point in the subscription lookup in the view, so I'm removing this wasted DB call.

Also, in the task, if the subscription doesn't exist, then it tries to change the status of this non-existant subscription, which makes no sense, so I removed that catch so that we get an error in sentry if we're trying to fire off a subscription that doesn't exist, so that we can investigate why that is.