### PR TITLE
Sync files from api

### DIFF
--- a/contentstore/tasks.py
+++ b/contentstore/tasks.py
@@ -25,7 +25,7 @@ class SyncAudioMessages(Task):
                     r = requests.get(make_absolute_url(item.content.url))
 
                     local_path = '{}{}'.format(src, item.content.name)
-                    with open(local_path, "w") as f:
+                    with open(local_path, "wb") as f:
                         f.write(r.content)
 
             root = settings.AUDIO_FTP_ROOT

--- a/contentstore/tasks.py
+++ b/contentstore/tasks.py
@@ -1,13 +1,32 @@
+import os
+import requests
+
 from celery.task import Task
 from django.conf import settings
 from sftpclone import sftpclone
+
+from .models import BinaryContent
+from subscriptions.tasks import make_absolute_url
 
 
 class SyncAudioMessages(Task):
 
     def run(self, **kwargs):
         if settings.AUDIO_FTP_HOST:
+
             src = '{}/{}/'.format(settings.BASE_DIR, settings.MEDIA_ROOT)
+
+            existing_files = os.listdir(src)
+
+            files = BinaryContent.objects.all()
+            for item in files.iterator():
+
+                if item.content.name not in existing_files:
+                    r = requests.get(make_absolute_url(item.content.url))
+
+                    local_path = '{}{}'.format(src, item.content.name)
+                    with open(local_path, "w") as f:
+                        f.write(r.content)
 
             root = settings.AUDIO_FTP_ROOT
             host = settings.AUDIO_FTP_HOST

--- a/contentstore/tests/test_general.py
+++ b/contentstore/tests/test_general.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from mock import patch
+import os
 
 import pytz
 import responses
@@ -14,7 +15,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.authtoken.models import Token
 
-from ..models import Schedule, MessageSet, Message
+from ..models import Schedule, MessageSet, Message, BinaryContent
 
 
 class APITestCase(TestCase):
@@ -513,13 +514,31 @@ class TestAdmin(MessageSetTestMixin, TestCase):
 
 class TestSyncWelcomeAudio(AuthenticatedAPITestCase):
 
+    def make_binarycontent(self, filename='hello.mp3'):
+        data = {
+            'content': filename,
+        }
+        return BinaryContent.objects.create(**data)
+
     @responses.activate
     @patch('sftpclone.sftpclone.SFTPClone.__init__')
     @patch('sftpclone.sftpclone.SFTPClone.run')
     def test_sync_welcome_audio(self, sftp_run_mock, sftp_mock):
+        """
+        When there is a POST to the sync audio api endpoint, it should sync the
+        audio files from the django api container then upload it to a sftp
+        folder.
+        """
 
         sftp_run_mock.return_value = None
         sftp_mock.return_value = None
+
+        self.make_binarycontent()
+
+        responses.add(responses.GET,
+                      "http://example.com/media/hello.mp3",
+                      "test file content",
+                      status=200, content_type='text/plain')
 
         response = self.client.post('/api/v1/sync_audio_files/',
                                     content_type='application/json')
@@ -529,3 +548,7 @@ class TestSyncWelcomeAudio(AuthenticatedAPITestCase):
         sftp_mock.assert_called_with(
             '{}/{}/'.format(settings.BASE_DIR, settings.MEDIA_ROOT),
             'test:secret@localhost:test_directory', port=2222, delete=False)
+
+        path = '{}/{}/hello.mp3'.format(settings.BASE_DIR, settings.MEDIA_ROOT)
+        self.assertTrue(os.path.isfile(path))
+        os.remove(path)


### PR DESCRIPTION
The `SyncAudioMessages` task is running inside a separate celery docker container, the celery container does not share a volume with the app container so it does not have direct access to the audio files. They are accessible through the API.

Shared volumes are explicitly not supported in our cluster (for a variety of good reasons). - from SRE.

The solution is to copy all audio files to the celery containers volume before doing the sftp clone. It will only copy files that don't exist on the ftp drive. It will clean up the files after cloning.