### PR TITLE
Add metadata has_key and not_has_key filters

### DIFF
--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -392,7 +392,7 @@ class TestSubscriptionsAPI(AuthenticatedAPITestCase):
 
         response = self.client.get(
             '/api/v1/subscriptions/',
-            {"metadata_contains": "new_key"},
+            {"metadata_has_key": "new_key"},
             content_type='application/json'
         )
 

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -380,7 +380,7 @@ class TestSubscriptionsAPI(AuthenticatedAPITestCase):
         ids = set(s['id'] for s in response.data['results'])
         self.assertEqual(set([str(sub1.id), str(sub2.id)]), ids)
 
-    def test_filter_subscription_metadata_contains(self):
+    def test_filter_subscription_metadata_has_key(self):
         sub1 = self.make_subscription()
         sub2 = self.make_subscription()
         self.make_subscription()
@@ -400,6 +400,25 @@ class TestSubscriptionsAPI(AuthenticatedAPITestCase):
         self.assertEqual(len(response.data['results']), 2)
         ids = set(s['id'] for s in response.data['results'])
         self.assertEqual(set([str(sub1.id), str(sub2.id)]), ids)
+
+    def test_filter_subscription_metadata_not_has_key(self):
+        sub1 = self.make_subscription()
+        sub2 = self.make_subscription()
+        sub3 = self.make_subscription()
+
+        sub2.metadata['new_key'] = 'things'
+        sub2.save()
+
+        response = self.client.get(
+            '/api/v1/subscriptions/',
+            {"metadata_not_has_key": "new_key"},
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 2)
+        ids = set(s['id'] for s in response.data['results'])
+        self.assertEqual(set([str(sub1.id), str(sub3.id)]), ids)
 
     def test_update_subscription_data(self):
         # Setup

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -380,6 +380,27 @@ class TestSubscriptionsAPI(AuthenticatedAPITestCase):
         ids = set(s['id'] for s in response.data['results'])
         self.assertEqual(set([str(sub1.id), str(sub2.id)]), ids)
 
+    def test_filter_subscription_metadata_contains(self):
+        sub1 = self.make_subscription()
+        sub2 = self.make_subscription()
+        self.make_subscription()
+
+        sub1.metadata['new_key'] = 'stuff'
+        sub1.save()
+        sub2.metadata['new_key'] = 'things'
+        sub2.save()
+
+        response = self.client.get(
+            '/api/v1/subscriptions/',
+            {"metadata_contains": "new_key"},
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 2)
+        ids = set(s['id'] for s in response.data['results'])
+        self.assertEqual(set([str(sub1.id), str(sub2.id)]), ids)
+
     def test_update_subscription_data(self):
         # Setup
         existing = self.make_subscription()

--- a/subscriptions/views.py
+++ b/subscriptions/views.py
@@ -28,8 +28,10 @@ class SubscriptionFilter(filters.FilterSet):
         name="created_at", lookup_type="gte")
     created_before = django_filters.IsoDateTimeFilter(
         name="created_at", lookup_type="lte")
-    metadata_contains = django_filters.CharFilter(name='metadata',
-                                                  lookup_type='has_key')
+    metadata_has_key = django_filters.CharFilter(name='metadata',
+                                                 lookup_type='has_key')
+    metadata_not_has_key = django_filters.CharFilter(
+        name='metadata', lookup_type='has_key', exclude=True)
 
     class Meta:
         model = Subscription

--- a/subscriptions/views.py
+++ b/subscriptions/views.py
@@ -28,6 +28,8 @@ class SubscriptionFilter(filters.FilterSet):
         name="created_at", lookup_type="gte")
     created_before = django_filters.IsoDateTimeFilter(
         name="created_at", lookup_type="lte")
+    metadata_contains = django_filters.CharFilter(name='metadata',
+                                                  lookup_type='has_key')
 
     class Meta:
         model = Subscription


### PR DESCRIPTION
We need to send a notification on public subscriptions that finish without moving to full registrations.

I plan on saving something in the subscription metadata to identify which subscriptions has already triggered a notification. These filters will allow us to filter properly.