### PR TITLE
New messageset shortname like filter

### DIFF
--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -412,6 +412,22 @@ class TestSubscriptionsAPI(AuthenticatedAPITestCase):
         ids = set(s['id'] for s in response.data['results'])
         self.assertEqual(set([str(sub1.id), str(sub3.id)]), ids)
 
+    def test_filter_subscription_messageset_contains(self):
+        self.make_subscription()
+        sub = self.make_subscription_audio()
+        self.make_subscription()
+
+        response = self.client.get(
+            '/api/v1/subscriptions/',
+            {"messageset_contains": "_two"},
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+        result_id = [s['id'] for s in response.data['results']][0]
+        self.assertEqual(str(sub.id), result_id)
+
     def test_update_subscription_data(self):
         # Setup
         existing = self.make_subscription()

--- a/subscriptions/views.py
+++ b/subscriptions/views.py
@@ -32,6 +32,8 @@ class SubscriptionFilter(filters.FilterSet):
                                                  lookup_type='has_key')
     metadata_not_has_key = django_filters.CharFilter(
         name='metadata', lookup_type='has_key', exclude=True)
+    messageset_contains = django_filters.CharFilter(
+        name='messageset__short_name', lookup_type='contains')
 
     class Meta:
         model = Subscription


### PR DESCRIPTION
This enables us to filter subscription by part of their messageset name.