### PR TITLE
Add validation for invalid whatsapp characters

### DIFF
--- a/contentstore/models.py
+++ b/contentstore/models.py
@@ -194,7 +194,7 @@ class Message(models.Model):
         if (
                 'whatsapp' in (self.messageset.channel or '').lower() and
                 self.WHATSAPP_INVALID_VALUE_PATTERN.findall(self.text_content)
-            ):
+                ):
             raise ValidationError(
                 _('Text for WhatsApp must not include newline, tabs, or 4 '
                   'consecutive spaces.')

--- a/contentstore/tests/test_general.py
+++ b/contentstore/tests/test_general.py
@@ -34,14 +34,15 @@ class MessageSetTestMixin():
         return Schedule.objects.create(**schedule_data)
 
     def make_messageset(self, short_name='messageset_one', notes=None,
-                        next_set=None, schedule=None):
+                        next_set=None, schedule=None, channel=None):
         if schedule is None:
             schedule = self.make_schedule()
         messageset_data = {
             'short_name': short_name,
             'notes': notes,
             'next_set': next_set,
-            'default_schedule': schedule
+            'default_schedule': schedule,
+            'channel': channel,
         }
         return MessageSet.objects.create(**messageset_data)
 

--- a/contentstore/tests/test_models.py
+++ b/contentstore/tests/test_models.py
@@ -50,7 +50,7 @@ class TestMessage(MessageSetTestMixin, TestCase):
         ]
         for message in messages:
             with self.assertRaises(ValidationError):
-                m = Message.objects.create(
+                Message.objects.create(
                     sequence_number=1,
                     messageset_id=messageset.id,
                     text_content=message,

--- a/contentstore/tests/test_models.py
+++ b/contentstore/tests/test_models.py
@@ -36,3 +36,22 @@ class TestMessage(MessageSetTestMixin, TestCase):
                 messageset_id=messageset.id,
                 text_content=special_chars,)
             m.full_clean()
+
+    def test_raises_validation_error_for_whatsapp_invalid_chars(self):
+        """
+        Should raise a validation error if any of the disallowed characters
+        are present in the text content.
+        """
+        messageset = self.make_messageset(channel='TEST_WHATSAPP_CHANNEL')
+        messages = [
+            "Message with \n newline",
+            "Message with \t tab",
+            "Message with    four spaces",
+        ]
+        for message in messages:
+            with self.assertRaises(ValidationError):
+                m = Message.objects.create(
+                    sequence_number=1,
+                    messageset_id=messageset.id,
+                    text_content=message,
+                )


### PR DESCRIPTION
With WhatsApp HSMs, we're not allowed newlines, tabs, or 4 spaces in message content. This PR ensures that we cannot upload any messages for any whatsapp channel with those characters.