### PR TITLE
Remove retry count check in on_failure 

### DIFF
--- a/subscriptions/tasks.py
+++ b/subscriptions/tasks.py
@@ -97,20 +97,19 @@ class BaseSendMessage(Task):
         """
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
-        if self.request.retries == 0:
-            if isinstance(args[0], dict):
-                subscription_id = args[0]["subscription_id"]
-            else:
-                subscription_id = args[0]
+        if isinstance(args[0], dict):
+            subscription_id = args[0]["subscription_id"]
+        else:
+            subscription_id = args[0]
 
-            SubscriptionSendFailure.objects.create(
-                subscription_id=subscription_id,
-                initiated_at=self.request.eta or now(),
-                reason=str(exc),
-                task_id=task_id
-            )
-        super(BaseSendMessage, self).on_failure(exc, task_id, args,
-                                                kwargs, einfo)
+        SubscriptionSendFailure.objects.create(
+            subscription_id=subscription_id,
+            initiated_at=self.request.eta or now(),
+            reason=str(exc),
+            task_id=task_id
+        )
+        super(BaseSendMessage, self).on_failure(exc, task_id, args, kwargs,
+                                                einfo)
 
 
 @app.task

--- a/subscriptions/tasks.py
+++ b/subscriptions/tasks.py
@@ -97,6 +97,9 @@ class BaseSendMessage(Task):
         """
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
+        # This function only gets called once all retries have failed, not with
+        # each retry, this was tested in real life but doesn't work with unit
+        # tests when CELERY_ALWAYS_EAGER is True
         if isinstance(args[0], dict):
             subscription_id = args[0]["subscription_id"]
         else:

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -28,14 +28,12 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.authtoken.models import Token
-from requests.exceptions import ConnectionError
 
 from .models import (Subscription, SubscriptionSendFailure, EstimatedSend,
                      fire_metrics_if_new,
                      ResendRequest)
 from contentstore.models import Schedule, MessageSet, BinaryContent, Message
-from .tasks import (schedule_disable, fire_metric, scheduled_metrics,
-                    send_next_message)
+from .tasks import schedule_disable, fire_metric, scheduled_metrics
 from . import tasks
 from seed_stage_based_messaging import test_utils as utils
 
@@ -1628,25 +1626,6 @@ class TestSendMessageTask(AuthenticatedAPITestCase):
         self.assertEqual(resend_request.message.sequence_number, 1)
         self.assertEqual(str(resend_request.outbound),
                          "c7f3c839-2bf5-42d1-86b9-ccb886645fb4")
-
-    @override_settings(CELERY_TASK_EAGER_PROPAGATES=False)
-    def test_on_failure_sending_tasks(self):
-        """
-        When something fails in a function task using BaseSendMessage as base
-        make sure the SubscriptionSendFailure item is created.
-        """
-
-        # Setup
-        existing = self.make_subscription_audio()
-        self.make_messages_audio(existing.messageset, 3)
-
-        with pytest.raises(ConnectionError) as excinfo:
-            send_next_message(str(existing.id))
-
-        self.assertTrue(
-            str(excinfo.value).find("Failed to establish a new conn") != -1)
-
-        self.assertEqual(SubscriptionSendFailure.objects.all().count(), 1)
 
     @override_settings(USE_SSL=True)
     def test_make_absolute_url(self):


### PR DESCRIPTION
The unit tests are being run with always eager set to true causing the on_failure to be called on every retry of the task. This is not the case where it is set to false, on_failure only gets called when the last retry fails.