### PR TITLE
Fix behind subscriptions monitoring triggering on 0 messages behind

### DIFF
--- a/subscriptions/tasks.py
+++ b/subscriptions/tasks.py
@@ -585,8 +585,8 @@ def calculate_subscription_lifecycle(subscription_id):
     ).get(
         id=subscription_id
     )
-    number, completed = subscription.get_expected_next_sequence_number()
-    if number <= subscription.next_sequence_number and completed is False:
+    behind = subscription.messages_behind()
+    if behind == 0:
         return
 
     current_messageset = subscription.messageset
@@ -595,7 +595,7 @@ def calculate_subscription_lifecycle(subscription_id):
         subscription, save=False)[-1]
     BehindSubscription.objects.create(
         subscription=subscription,
-        messages_behind=number - current_sequence_number,
+        messages_behind=behind,
         current_messageset=current_messageset,
         current_sequence_number=current_sequence_number,
         expected_messageset=end_subscription.messageset,

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -2463,7 +2463,7 @@ class TestFixSubscriptionLifecycle(AuthenticatedAPITestCase):
         self.assertEqual(stderr.getvalue(), '')
         self.assertEqual(
             stdout.getvalue().strip(),
-            "{}: 2\n"
+            "{}: 3\n"
             "1 subscription behind schedule.\n"
             "0 subscriptions fast forwarded to end date.\n"
             "Message sent to 0 subscriptions.".format(sub1.id))
@@ -2872,6 +2872,7 @@ class TestFixSubscriptionLifecycle(AuthenticatedAPITestCase):
                 'current_sequence_number': 1,
                 'expected_messageset_id': self.messageset_second.pk,
                 'expected_sequence_number': 0,
+                'messages_behind': 3,
             })
 
         # Ensure that we haven't changed any of the subscriptions

--- a/subscriptions/tests/test_models.py
+++ b/subscriptions/tests/test_models.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from django.test import TestCase
+
+from contentstore.models import MessageSet, Message, Schedule
+from subscriptions.models import Subscription
+from seed_stage_based_messaging import test_utils as utils
+
+
+class SubscriptionTest(TestCase):
+    def setUp(self):
+        utils.disable_signals()
+
+    def tearDown(self):
+        utils.enable_signals()
+
+    def create_messageset_with_messages(self, name, schedule, n):
+        """
+        Creates and returns a messageset with n messages
+        """
+        messageset = MessageSet.objects.create(
+            default_schedule=schedule, short_name=name)
+        for i in range(n):
+            Message.objects.create(
+                messageset=messageset, text_content=str(i),
+                sequence_number=(i + 1), lang="eng_ZA"
+            )
+        return messageset
+
+    def test_messages_behind(self):
+        """
+        Ensures that it returns the correct number of messages behind
+        """
+        messageset1 = self.create_messageset_with_messages(
+            'ms1', Schedule.objects.create(minute="0"), 2)
+        messageset2 = self.create_messageset_with_messages(
+            'ms2', Schedule.objects.create(), 0)
+        messageset3 = self.create_messageset_with_messages(
+            'ms3', Schedule.objects.create(minute="0", hour="*/2"), 2)
+        messageset1.next_set = messageset2
+        messageset1.save()
+        messageset2.next_set = messageset3
+        messageset2.save()
+
+        # Should be on second message of 1st set, so 1 message behind
+        start = datetime(2018, 1, 1, 0, 0, 0)
+        end = datetime(2018, 1, 1, 1, 0, 0)
+        sub = Subscription(
+            created_at=start,
+            messageset=messageset1,
+            schedule=messageset1.default_schedule,
+            lang="eng_ZA"
+        )
+        self.assertEqual(sub.messages_behind(end), 1)
+
+        # Should be on first message of 3rd set, so 2 messages behind
+        end = datetime(2018, 1, 1, 2, 0, 0)
+        self.assertEqual(sub.messages_behind(end), 2)
+
+        # Should be on second message of 3rd set, so 3 messages behind
+        end = datetime(2018, 1, 1, 4, 0, 0)
+        self.assertEqual(sub.messages_behind(end), 3)


### PR DESCRIPTION
The way the amount of messages behind was calculated previously was inaccurate. This PR adds a `messages_behind` method to the Subscription model to accurately calculate the number of messages behind a subscription is, across the subscription chain.

It then uses this function in all the places that we need the number of messages behind a subscription is.