### PR TITLE
Add prometheus metrics

### DIFF
--- a/seed_stage_based_messaging/decorators.py
+++ b/seed_stage_based_messaging/decorators.py
@@ -1,0 +1,21 @@
+import functools
+
+from django.core.exceptions import PermissionDenied
+
+
+def internal_only(view_func):
+    """
+    A view decorator which blocks access for requests coming through the load balancer.
+    """
+
+    @functools.wraps(view_func)
+    def wrapper(request, *args, **kwargs):
+        forwards = request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")
+        # The nginx in the docker container adds the loadbalancer IP to the list inside
+        # X-Forwarded-For, so if the list contains more than a single item, we know
+        # that it went through our loadbalancer
+        if len(forwards) > 1:
+            raise PermissionDenied()
+        return view_func(request, *args, **kwargs)
+
+    return wrapper

--- a/seed_stage_based_messaging/settings.py
+++ b/seed_stage_based_messaging/settings.py
@@ -88,7 +88,7 @@ DATABASES = {
     )
 }
 
-PROMETHEUS_EXPORT_MIGRATRIONS = False
+PROMETHEUS_EXPORT_MIGRATIONS = False
 
 
 # Internationalization

--- a/seed_stage_based_messaging/settings.py
+++ b/seed_stage_based_messaging/settings.py
@@ -192,7 +192,6 @@ CELERY_TASK_ROUTES = {
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 50
 
 METRICS_REALTIME = [
-    "subscriptions.created.sum",
     "subscriptions.send_next_message_errored.sum",
     "sbm.send_next_message.connection_error.sum",
     "sbm.send_next_message.http_error.400.sum",

--- a/seed_stage_based_messaging/settings.py
+++ b/seed_stage_based_messaging/settings.py
@@ -88,6 +88,8 @@ DATABASES = {
     )
 }
 
+PROMETHEUS_EXPORT_MIGRATRIONS = False
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/

--- a/seed_stage_based_messaging/settings.py
+++ b/seed_stage_based_messaging/settings.py
@@ -12,7 +12,6 @@ import mimetypes
 import os
 
 import dj_database_url
-import django_cache_url
 from kombu import Exchange, Queue
 
 # Support SVG on admin
@@ -51,18 +50,21 @@ INSTALLED_APPS = (
     "rest_framework",
     "rest_framework.authtoken",
     "django_filters",
+    "django_prometheus",
     # us
     "contentstore",
     "subscriptions",
 )
 
 MIDDLEWARE = (
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 )
 
 SITE_ID = 1
@@ -81,7 +83,8 @@ DATABASES = {
         default=os.environ.get(
             "STAGE_BASED_MESSAGING_DATABASE",
             "postgres://postgres:@localhost/seed_stage_based_messaging",
-        )
+        ),
+        engine="django_prometheus.db.backends.postgresql",
     )
 }
 
@@ -187,9 +190,6 @@ CELERY_TASK_ROUTES = {
 }
 
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 50
-
-CACHE_URL = os.environ.get("STAGE_BASED_MESSAGING_CACHE", "locmem://")
-CACHES = {"default": django_cache_url.parse(CACHE_URL)}
 
 METRICS_REALTIME = [
     "subscriptions.created.sum",

--- a/seed_stage_based_messaging/test_decorators.py
+++ b/seed_stage_based_messaging/test_decorators.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+
+class InternalOnlyTests(TestCase):
+    def test_internal_access(self):
+        """
+        Internal access should be allowed
+        """
+        url = reverse("metrics")
+        response = self.client.get(url, HTTP_X_FORWARDED_FOR="1.2.3.4")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_external_access(self):
+        """
+        External access through the load balancer should be blocked
+        """
+        url = reverse("metrics")
+        response = self.client.get(url, HTTP_X_FORWARDED_FOR="1.2.3.4, 4.3.2.1")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/seed_stage_based_messaging/test_utils.py
+++ b/seed_stage_based_messaging/test_utils.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 
 from contentstore.models import Schedule
 from contentstore.signals import schedule_deleted, schedule_saved
-from subscriptions.models import Subscription, fire_metrics_if_new
 
 from .utils import normalise_metric_name
 
@@ -19,7 +18,7 @@ class NormaliseMetricNameTest(TestCase):
         self.assertEqual(normalise_metric_name("_foo!bar,"), "foo_bar")
 
 
-post_save_signals = ((fire_metrics_if_new, Subscription), (schedule_saved, Schedule))
+post_save_signals = ((schedule_saved, Schedule),)
 
 
 post_delete_signals = ((schedule_deleted, Schedule),)

--- a/seed_stage_based_messaging/urls.py
+++ b/seed_stage_based_messaging/urls.py
@@ -7,6 +7,7 @@ from django_prometheus import exports as django_prometheus
 from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.documentation import include_docs_urls
 
+from seed_stage_based_messaging.decorators import internal_only
 from subscriptions import views
 
 admin.site.site_header = os.environ.get(
@@ -23,5 +24,7 @@ urlpatterns = [
     url(r"^", include("subscriptions.urls")),
     url(r"^", include("contentstore.urls")),
     url(r"^docs/", include_docs_urls(title="Seed Stage Based Messaging")),
-    path("metrics", django_prometheus.ExportToDjangoView, name="metrics"),
+    path(
+        "metrics", internal_only(django_prometheus.ExportToDjangoView), name="metrics"
+    ),
 ]

--- a/seed_stage_based_messaging/urls.py
+++ b/seed_stage_based_messaging/urls.py
@@ -3,6 +3,7 @@ import os
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.urls import path
+from django_prometheus import exports as django_prometheus
 from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.documentation import include_docs_urls
 
@@ -22,4 +23,5 @@ urlpatterns = [
     url(r"^", include("subscriptions.urls")),
     url(r"^", include("contentstore.urls")),
     url(r"^docs/", include_docs_urls(title="Seed Stage Based Messaging")),
+    path("metrics", django_prometheus.ExportToDjangoView, name="metrics"),
 ]

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,8 @@ setup(
         "requests==2.18.4",
         "seed-services-client==0.37.0",
         "croniter==0.3.25",
-        "django-cache-url==3.0.0",
-        "django-redis==4.9.0",
         "sftpclone==1.2.2",
+        "django-prometheus==1.0.15",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/subscriptions/models.py
+++ b/subscriptions/models.py
@@ -4,8 +4,6 @@ from datetime import timedelta
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import JSONField
 from django.db import models
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import now
 
@@ -203,16 +201,6 @@ class Subscription(models.Model):
             self.process_status == 0
             and self.completed is not True
             and self.active is True
-        )
-
-
-@receiver(post_save, sender=Subscription)
-def fire_metrics_if_new(sender, instance, created, **kwargs):
-    from .tasks import fire_metric
-
-    if created:
-        fire_metric.apply_async(
-            kwargs={"metric_name": "subscriptions.created.sum", "metric_value": 1.0}
         )
 
 

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -43,7 +43,7 @@ class APITestCase(TestCase):
 class AuthenticatedAPITestCase(APITestCase):
     def make_schedule(self):
         # Create hourly schedule
-        schedule_data = {"hour": 1}
+        schedule_data = {"day_of_month": 1, "hour": 1, "minute": 0}
         return Schedule.objects.create(**schedule_data)
 
     def make_messageset(self):
@@ -2934,6 +2934,9 @@ class TestFixSubscriptionLifecycle(AuthenticatedAPITestCase):
         self.assertEqual(updated_sub.next_sequence_number, 3)
 
     def test_diff_action(self):
+        import cProfile
+        prof = cProfile.Profile()
+        prof.enable()
         stdout, stderr = StringIO(), StringIO()
 
         self.make_subscription()
@@ -2978,6 +2981,8 @@ class TestFixSubscriptionLifecycle(AuthenticatedAPITestCase):
         self.assertEqual(Subscription.objects.count(), 3)
         for sub in Subscription.objects.all():
             self.assertEqual(sub.next_sequence_number, 1)
+        prof.disable()
+        prof.dump_stats('stats.cprof')
 
     def test_filter_by_messageset(self):
         stdout, stderr = StringIO(), StringIO()

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -2934,9 +2934,6 @@ class TestFixSubscriptionLifecycle(AuthenticatedAPITestCase):
         self.assertEqual(updated_sub.next_sequence_number, 3)
 
     def test_diff_action(self):
-        import cProfile
-        prof = cProfile.Profile()
-        prof.enable()
         stdout, stderr = StringIO(), StringIO()
 
         self.make_subscription()
@@ -2981,8 +2978,6 @@ class TestFixSubscriptionLifecycle(AuthenticatedAPITestCase):
         self.assertEqual(Subscription.objects.count(), 3)
         for sub in Subscription.objects.all():
             self.assertEqual(sub.next_sequence_number, 1)
-        prof.disable()
-        prof.dump_stats('stats.cprof')
 
     def test_filter_by_messageset(self):
         stdout, stderr = StringIO(), StringIO()

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -9,7 +9,6 @@ import responses
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import call_command
-from django.db.models.signals import post_save
 from django.test import TestCase, override_settings
 from django.utils import timezone
 from requests.exceptions import HTTPError
@@ -21,13 +20,7 @@ from contentstore.models import BinaryContent, Message, MessageSet, Schedule
 from seed_stage_based_messaging import test_utils as utils
 
 from . import tasks
-from .models import (
-    EstimatedSend,
-    ResendRequest,
-    Subscription,
-    SubscriptionSendFailure,
-    fire_metrics_if_new,
-)
+from .models import EstimatedSend, ResendRequest, Subscription, SubscriptionSendFailure
 from .tasks import BaseSendMessage, fire_metric, schedule_disable, scheduled_metrics
 
 try:
@@ -1795,7 +1788,6 @@ class TestMetricsAPI(AuthenticatedAPITestCase):
                     "sbm.send_next_message.http_error.404.sum",
                     "sbm.send_next_message.http_error.500.sum",
                     "sbm.send_next_message.timeout.sum",
-                    "subscriptions.created.sum",
                     "subscriptions.send.estimate.0.last",
                     "subscriptions.send.estimate.1.last",
                     "subscriptions.send.estimate.2.last",
@@ -1856,49 +1848,6 @@ class TestMetrics(AuthenticatedAPITestCase):
         request = responses.calls[-1].request
         self.check_request(request, "POST", data={"foo.last": 1.0})
         self.assertEqual(result.get(), "Fired metric <foo.last> with value <1.0>")
-
-    @responses.activate
-    def test_created_metrics(self):
-        """
-        When a new subscription is created, the correct metric should be sent
-        to the metrics API.
-        """
-        # reconnect metric post_save hook
-        post_save.connect(fire_metrics_if_new, sender=Subscription)
-
-        # Execute
-        self.make_subscription()
-
-        # Check
-        request = responses.calls[-1].request
-        self.check_request(request, "POST", data={"subscriptions.created.sum": 1.0})
-        # remove post_save hooks to prevent teardown errors
-        post_save.disconnect(fire_metrics_if_new, sender=Subscription)
-
-    @responses.activate
-    def test_multiple_created_metrics(self):
-        # Setup
-        # deactivate Testsession for this test
-        self.session = None
-        # reconnect metric post_save hook
-        post_save.connect(fire_metrics_if_new, sender=Subscription)
-        # add metric post response
-        responses.add(
-            responses.POST,
-            "http://metrics-url/metrics/",
-            json={"foo": "bar"},
-            status=200,
-            content_type="application/json",
-        )
-
-        # Execute
-        self.make_subscription()
-        self.make_subscription()
-
-        # Check
-        self.assertEqual(len(responses.calls), 2)
-        # remove post_save hooks to prevent teardown errors
-        post_save.disconnect(fire_metrics_if_new, sender=Subscription)
 
     @responses.activate
     def test_scheduled_metrics(self):


### PR DESCRIPTION
This PR adds basic django prometheus metrics, and removes the not-required subscription creation metric.