### PR TITLE
Make sure subscription.updated_at is updated

### DIFF
--- a/subscriptions/tasks.py
+++ b/subscriptions/tasks.py
@@ -360,8 +360,9 @@ def post_send_process(context):
             subscription.completed = True
             subscription.active = False
             subscription.process_status = 2  # Completed
+            subscription.updated_at = now()
             deserialized_subscription.save(
-                update_fields=("completed", "active", "process_status")
+                update_fields=("completed", "active", "process_status", "updated_at")
             )
             # If next set defined create new subscription
             if messageset.next_set:
@@ -379,9 +380,10 @@ def post_send_process(context):
         subscription.next_sequence_number = F("next_sequence_number") + 1
         logger.debug("setting process status back to 0")
         subscription.process_status = 0
+        subscription.updated_at = now()
         logger.debug("saving subscription")
         deserialized_subscription.save(
-            update_fields=("next_sequence_number", "process_status")
+            update_fields=("next_sequence_number", "process_status", "updated_at")
         )
     # return response
     return "Subscription for %s updated" % str(subscription.id)
@@ -411,7 +413,8 @@ def post_send_process_resend(context):
         resend_request.message_id = message.id
         resend_request.save(update_fields=("outbound", "message_id"))
         subscription.process_status = 0
-        deserialized_subscription.save(update_fields=("process_status",))
+        subscription.updated_at = now()
+        deserialized_subscription.save(update_fields=("process_status", "updated_at"))
 
 
 send_next_message = (

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -540,6 +540,10 @@ class TestSendMessageTask(AuthenticatedAPITestCase):
         self.messageset.channel = "CHANNEL1"
         self.messageset.save()
 
+        Subscription.objects.all().update(
+            updated_at=datetime(2017, 10, 31, tzinfo=timezone.utc)
+        )
+
         # Precheck
         subs_all = Subscription.objects.all()
         self.assertEqual(subs_all.count(), 1)
@@ -663,6 +667,8 @@ class TestSendMessageTask(AuthenticatedAPITestCase):
         self.assertEqual(d.active, True)
         self.assertEqual(d.completed, False)
         self.assertEqual(d.process_status, 0)
+        self.assertNotEqual(d.updated_at, datetime(2017, 10, 31, tzinfo=timezone.utc))
+
         subs_all = Subscription.objects.all()
         self.assertEqual(subs_all.count(), 1)
         scheds_all = Schedule.objects.all()
@@ -876,6 +882,10 @@ class TestSendMessageTask(AuthenticatedAPITestCase):
         existing.next_sequence_number = 2  # fast forward to end
         existing.save()
 
+        Subscription.objects.all().update(
+            updated_at=datetime(2017, 10, 31, tzinfo=timezone.utc)
+        )
+
         # add a next message set
         messageset_data = {
             "short_name": "messageset_two_text",
@@ -962,6 +972,7 @@ class TestSendMessageTask(AuthenticatedAPITestCase):
         self.assertEqual(d.completed, True)
         self.assertEqual(d.process_status, 2)
         self.assertEqual(len(responses.calls), 2)
+        self.assertNotEqual(d.updated_at, datetime(2017, 10, 31, tzinfo=timezone.utc))
 
         # make sure a subscription is created on the next message set
         subs_active = Subscription.objects.filter(
@@ -1566,6 +1577,10 @@ class TestSendMessageTask(AuthenticatedAPITestCase):
         # Setup
         existing = self.make_subscription_audio({"next_sequence_number": 2})
 
+        Subscription.objects.all().update(
+            updated_at=datetime(2017, 10, 31, tzinfo=timezone.utc)
+        )
+
         # mock identity address lookup
         responses.add(
             responses.GET,
@@ -1623,6 +1638,7 @@ class TestSendMessageTask(AuthenticatedAPITestCase):
         self.assertEqual(d.active, True)
         self.assertEqual(d.completed, False)
         self.assertEqual(d.process_status, 0)
+        self.assertNotEqual(d.updated_at, datetime(2017, 10, 31, tzinfo=timezone.utc))
 
         outbound_call = responses.calls[1]
         self.assertEqual(


### PR DESCRIPTION
For the seed-stage-based-messaging component, we did some performance improvements. Some of these improvements involved limiting which fields we write to when processing a subscription for sending. The issue here is that the updated_at field is not included in that list of fields, so the updated_at timestamp is no longer being updated.

This causes some confusion, and also creates issues with our monitoring (we check if there are any subscriptions still processing that were last updated more than an hour ago, and since the updated_at isn't being updated, as soon as we process a subscription it shows up as a subscription that's still processing that was updated more than an hour ago)