### PR TITLE
Feature/momza 1165 caching for message lookup

### DIFF
--- a/seed_stage_based_messaging/settings.py
+++ b/seed_stage_based_messaging/settings.py
@@ -151,7 +151,7 @@ CACHES = {
     "default": env.cache(default="locmemcache://"),
     "locmem": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "TIMEOUT": 60,
+        "TIMEOUT": 60 * 60,
         "OPTIONS": {"MAX_ENTRIES": 300000},
     },
 }

--- a/seed_stage_based_messaging/settings.py
+++ b/seed_stage_based_messaging/settings.py
@@ -12,11 +12,14 @@ import mimetypes
 import os
 
 import dj_database_url
+import environ
 from kombu import Exchange, Queue
 
 # Support SVG on admin
 mimetypes.add_type("image/svg+xml", ".svg", True)
 mimetypes.add_type("image/svg+xml", ".svgz", True)
+
+env = environ.Env()
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -142,6 +145,11 @@ STAGE_BASED_MESSAGING_SENTRY_DSN = os.environ.get(
 RAVEN_CONFIG = {
     # DevOps will supply you with this.
     "dsn": STAGE_BASED_MESSAGING_SENTRY_DSN
+}
+
+CACHES = {
+    "default": env.cache(default="locmemcache://"),
+    "locmem": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
 }
 
 # REST Framework conf defaults

--- a/seed_stage_based_messaging/settings.py
+++ b/seed_stage_based_messaging/settings.py
@@ -149,7 +149,11 @@ RAVEN_CONFIG = {
 
 CACHES = {
     "default": env.cache(default="locmemcache://"),
-    "locmem": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+    "locmem": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "TIMEOUT": 60,
+        "OPTIONS": {"MAX_ENTRIES": 300000},
+    },
 }
 
 # REST Framework conf defaults

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "croniter==0.3.25",
         "sftpclone==1.2.2",
         "django-prometheus==1.0.15",
+        "django-environ==0.4.5",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/subscriptions/tasks.py
+++ b/subscriptions/tasks.py
@@ -3,6 +3,8 @@ try:
 except ImportError:
     from urllib.parse import urlunparse
 
+from functools import partial
+
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.task import Task
 from celery.utils.log import get_task_logger
@@ -10,6 +12,7 @@ from demands import HTTPServiceError
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import serializers
+from django.core.cache import caches
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import Count, F, Q
@@ -21,8 +24,6 @@ from seed_services_client.metrics import MetricsApiClient
 from contentstore.models import Message, Schedule
 from seed_stage_based_messaging import utils
 from seed_stage_based_messaging.celery import app
-from django.core.cache import caches
-from functools import partial
 
 from .models import (
     BehindSubscription,

--- a/subscriptions/test_tasks.py
+++ b/subscriptions/test_tasks.py
@@ -125,8 +125,6 @@ class CachedMessageLookupTests(TestCase):
         subscription_2 = Subscription.objects.create(
             schedule=schedule, messageset=messageset
         )
-        subscription_1.save()
-        subscription_2.save()
 
         with self.assertNumQueries(3):
             pre_send_process(subscription_1.id)
@@ -148,14 +146,11 @@ class CachedMessageLookupTests(TestCase):
         subscription = Subscription.objects.create(
             schedule=schedule, messageset=messageset
         )
-        subscription.save()
 
         res = pre_send_process(subscription.id)
 
         with self.assertNumQueries(2):
             post_send_process(res)
-
-        subscription.save()
 
         with self.assertNumQueries(1):
             post_send_process(res)

--- a/subscriptions/test_tasks.py
+++ b/subscriptions/test_tasks.py
@@ -11,8 +11,8 @@ from subscriptions.models import BehindSubscription, Subscription
 from subscriptions.tasks import (
     calculate_subscription_lifecycle,
     find_behind_subscriptions,
-    pre_send_process,
     post_send_process,
+    pre_send_process,
 )
 
 

--- a/subscriptions/test_tasks.py
+++ b/subscriptions/test_tasks.py
@@ -125,8 +125,6 @@ class CachedMessageLookupTests(TestCase):
         subscription_2 = Subscription.objects.create(
             schedule=schedule, messageset=messageset
         )
-        subscription_1.created_at = datetime.now() - timedelta(hours=2)
-        subscription_2.created_at = datetime.now() - timedelta(hours=2)
         subscription_1.save()
         subscription_2.save()
 
@@ -150,8 +148,6 @@ class CachedMessageLookupTests(TestCase):
         subscription = Subscription.objects.create(
             schedule=schedule, messageset=messageset
         )
-
-        subscription.created_at = datetime.now() - timedelta(hours=2)
         subscription.save()
 
         res = pre_send_process(subscription.id)
@@ -159,7 +155,6 @@ class CachedMessageLookupTests(TestCase):
         with self.assertNumQueries(2):
             post_send_process(res)
 
-        subscription.process_status = 0
         subscription.save()
 
         with self.assertNumQueries(1):

--- a/subscriptions/test_tasks.py
+++ b/subscriptions/test_tasks.py
@@ -11,6 +11,8 @@ from subscriptions.models import BehindSubscription, Subscription
 from subscriptions.tasks import (
     calculate_subscription_lifecycle,
     find_behind_subscriptions,
+    pre_send_process,
+    post_send_process,
 )
 
 
@@ -103,3 +105,62 @@ class TestCalculateSubscriptionLifecycle(TestCase):
         )
         self.assertEqual(behind.expected_messageset, subscription.messageset)
         self.assertEqual(behind.expected_sequence_number, 3)
+
+
+class CachedMessageLookupTests(TestCase):
+    def test_caching_message_lookup_working(self):
+        """
+        Ensure that the second time we make a request, there's no database hit
+        """
+        with disable_signal("post_save", schedule_saved, Schedule):
+            schedule = Schedule.objects.create(minute=0)
+        messageset = MessageSet.objects.create(default_schedule=schedule)
+        for i in range(10):
+            Message.objects.create(
+                messageset=messageset, text_content=str(i), sequence_number=i
+            )
+        subscription_1 = Subscription.objects.create(
+            schedule=schedule, messageset=messageset
+        )
+        subscription_2 = Subscription.objects.create(
+            schedule=schedule, messageset=messageset
+        )
+        subscription_1.created_at = datetime.now() - timedelta(hours=2)
+        subscription_2.created_at = datetime.now() - timedelta(hours=2)
+        subscription_1.save()
+        subscription_2.save()
+
+        with self.assertNumQueries(3):
+            pre_send_process(subscription_1.id)
+
+        with self.assertNumQueries(2):
+            pre_send_process(subscription_2.id)
+
+    def test_cache_message_count_working(self):
+        """
+        Ensure that the second time we do a message_count, there's no database hit
+        """
+        with disable_signal("post_save", schedule_saved, Schedule):
+            schedule = Schedule.objects.create(minute=0)
+        messageset = MessageSet.objects.create(default_schedule=schedule)
+        for i in range(3):
+            Message.objects.create(
+                messageset=messageset, text_content=str(i), sequence_number=i
+            )
+        subscription = Subscription.objects.create(
+            schedule=schedule, messageset=messageset
+        )
+
+        subscription.created_at = datetime.now() - timedelta(hours=2)
+        subscription.save()
+
+        res = pre_send_process(subscription.id)
+
+        with self.assertNumQueries(2):
+            post_send_process(res)
+
+        subscription.process_status = 0
+        subscription.save()
+
+        with self.assertNumQueries(1):
+            post_send_process(res)


### PR DESCRIPTION
In this PR we add in-memory cache for looking up a message (to know what content to send to the user), as well as the counting of messages in a subscription (so that we know whether to bump the person to the next messageset or not)