### PR TITLE
Move the subscription lock to an expiring key in the cache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,3 +10,6 @@ The Stage-Based Messaging Store has the following key responsibilities:
 - Store the stage-based content (both audio and text).
 - Store the stage-based content schedules.
 - Store the stage-based content subscriptions for each user.
+
+This uses the django cache framework to provide locking for the processing of
+subscriptions, so please ensure that the `REDIS_URL` setting is set.

--- a/seed_stage_based_messaging/settings.py
+++ b/seed_stage_based_messaging/settings.py
@@ -154,6 +154,7 @@ CACHES = {
         "TIMEOUT": 60 * 60,
         "OPTIONS": {"MAX_ENTRIES": 300000},
     },
+    "redis": env.cache("REDIS_URL", default="locmemcache://"),
 }
 
 # REST Framework conf defaults
@@ -262,3 +263,5 @@ AUDIO_FTP_ROOT = os.environ.get("AUDIO_FTP_ROOT")
 DRY_RUN_MESSAGESETS = map(
     int, filter(bool, os.environ.get("DRY_RUN_MESSAGESETS", "").split(","))
 )
+
+SUBSCRIPTION_LOCK_TIMEOUT: int = env.int("SUBSCRIPTION_LOCK_TIMEOUT", default=60 * 5)

--- a/subscriptions/tasks.py
+++ b/subscriptions/tasks.py
@@ -3,12 +3,12 @@ try:
 except ImportError:
     from urllib.parse import urlunparse
 
+from datetime import timedelta
 from functools import partial
 
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.task import Task
 from celery.utils.log import get_task_logger
-from datetime import timedelta
 from demands import HTTPServiceError
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site

--- a/subscriptions/test_tasks.py
+++ b/subscriptions/test_tasks.py
@@ -126,10 +126,10 @@ class CachedMessageLookupTests(TestCase):
             schedule=schedule, messageset=messageset
         )
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             pre_send_process(subscription_1.id)
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             pre_send_process(subscription_2.id)
 
     def test_cache_message_count_working(self):


### PR DESCRIPTION
This allows us to hit the database less (only a single update when processing the subscription), allows us to be able to expire the lock, changing it to a lease so that subscriptions cannot be stuck forever, and allows us to do retries in the case that a subscription is locked.